### PR TITLE
feat: add language state management with context and cookies

### DIFF
--- a/src/app/(route)/layout.tsx
+++ b/src/app/(route)/layout.tsx
@@ -9,6 +9,9 @@ import { pretendard } from "fonts";
 //contexts
 import { LanguageProvider } from "@/context/LanguageContext";
 
+//cookies
+import { cookies } from "next/headers";
+
 //components
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -18,11 +21,15 @@ export const metadata: Metadata = {
   description: "by Next.js 14",
 };
 
-export default function RootLayout({ children, }: Readonly <{ children: React.ReactNode;}>) {
+export default async function RootLayout({ children, }: Readonly <{ children: React.ReactNode;}>) {
+
+  const cookieStore = await cookies();
+  const initialLang = (cookieStore.get('lang')?.value as 'en' | 'ko') || 'en';
+
   return (
-    <html lang="en">
+    <html lang="{initialLang}">
       <body className={`${pretendard.variable} font-sans antialiased`}>
-        <LanguageProvider>
+        <LanguageProvider initialLang={initialLang}>
           <Header />
           {children}
           <Footer />

--- a/src/app/_actions/setLanguage.tsx
+++ b/src/app/_actions/setLanguage.tsx
@@ -1,0 +1,12 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+export async function setLanguage(lang: 'en' | 'ko') {
+  const cookieStore = await cookies();
+  cookieStore.set('lang', lang, {
+    httpOnly: false,
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30, // 30일 유지
+  });
+}

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, ReactNode } from "react";
+import { setLanguage } from "@/actions/setLanguage";
 
 type Lang = 'en' | 'ko';
 
@@ -12,10 +13,15 @@ interface LanguageContextProps {
 
 const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
 
-export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [lang, setLang] = useState<Lang>('en');
+export function LanguageProvider({ children, initialLang }: { children: ReactNode, initialLang: Lang }) {
+  const [lang, setLangState] = useState<Lang>(initialLang);
 
-  const toggleLang = () => setLang((prev) => (prev === 'en' ? 'ko' : 'en'));
+  const setLang = (newLang: Lang) => {
+    setLangState(newLang);
+    setLanguage(newLang); // save to cookie
+  }
+
+  const toggleLang = () => setLang(lang === 'en' ? 'ko' : 'en');
 
   return (
     <LanguageContext.Provider value={{ lang, setLang, toggleLang }}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "paths": {
       "@/styles/*": ["app/_styles/*"],
       "@/components/*": ["app/_components/*"],
+      "@/actions/*": ["app/_actions/*"],
       "@/context/*": ["context/*"],
       "@/locales/*": ["locales/*"],
     }


### PR DESCRIPTION
- Wrote setLanguage.tsx action to set language cookie.
- Updated LanguageContext to initialize language from props and save changes to cookies.
- Modified RootLayout to read initial language from cookies and pass to LanguageProvider.
- Updated tsconfig.json to include actions path.